### PR TITLE
Managed functions can throw Lua errors

### DIFF
--- a/gm_dotnet_managed/GmodNET.API/GmodNET.API.csproj
+++ b/gm_dotnet_managed/GmodNET.API/GmodNET.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.6.0-preview</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Gleb Krasilich</Authors>
     <Product>GmodNET API</Product>
@@ -13,7 +13,7 @@
     <PackageReleaseNotes>- TBD</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/GlebChili/GmodDotNet</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GlebChili/GmodDotNet/devel_netcore_2/MetaInfo/Logo/gmodnetlogo.png</PackageIconUrl>
-    <PackageVersion>0.6.0</PackageVersion>
+    <PackageVersion>0.6.0-preview</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/gm_dotnet_managed/GmodNET.API/ILua.cs
+++ b/gm_dotnet_managed/GmodNET.API/ILua.cs
@@ -164,13 +164,12 @@ namespace GmodNET.API
         public void PushBool(bool val);
         /// <summary>
         /// Pushes the given managed function on to the stack. The managed function will be converted to the C function.
-        /// If argument use_safe_error_wrapper is true (by default), managed function is wrapped in a C closure, which allows managed code to throw Lua exceptions (errors)
-        /// by following convention: to throw Lua error from managed code, CFuncManagedDelegate should push an error message onto the stack as string and return with
-        /// negative integer.
+        /// If argument use_safe_error_wrapper is true (by default), managed function is wrapped in a C closure, which allows managed code to throw exceptions, which are 
+        /// converted to Lua errors.
         /// CClosure, not CFunction, is pushed as a result if use_safe_error_wrapper is true.
         /// </summary>
         /// <param name="managed_function">Function to push</param>
-        /// <param name="use_safe_error_wrapper">If true, managed fucntion is wrapped in a CClosur, which allows managed code to throw Lua exceptions</param>
+        /// <param name="use_safe_error_wrapper">If true, managed fucntion is wrapped in a CClosur, which allows managed code to throw exceptions safely</param>
         public void PushCFunction(CFuncManagedDelegate managed_function, bool use_safe_error_wrapper = true);
         /// <summary>
         /// Pushes the given C-Function on to the stack. Native C function must be of signature "int Func(void*)".

--- a/gm_dotnet_managed/GmodNET.API/ILua.cs
+++ b/gm_dotnet_managed/GmodNET.API/ILua.cs
@@ -164,9 +164,14 @@ namespace GmodNET.API
         public void PushBool(bool val);
         /// <summary>
         /// Pushes the given managed function on to the stack. The managed function will be converted to the C function.
+        /// If argument use_safe_error_wrapper is true (by default), managed function is wrapped in a C closure, which allows managed code to throw Lua exceptions (errors)
+        /// by following convention: to throw Lua error from managed code, CFuncManagedDelegate should push an error message onto the stack as string and return with
+        /// negative integer.
+        /// CClosure, not CFunction, is pushed as a result if use_safe_error_wrapper is true.
         /// </summary>
         /// <param name="managed_function">Function to push</param>
-        public void PushCFunction(CFuncManagedDelegate managed_function);
+        /// <param name="use_safe_error_wrapper">If true, managed fucntion is wrapped in a CClosur, which allows managed code to throw Lua exceptions</param>
+        public void PushCFunction(CFuncManagedDelegate managed_function, bool use_safe_error_wrapper = true);
         /// <summary>
         /// Pushes the given C-Function on to the stack. Native C function must be of signature "int Func(void*)".
         /// </summary>

--- a/gm_dotnet_managed/GmodNET/Lua.cs
+++ b/gm_dotnet_managed/GmodNET/Lua.cs
@@ -313,11 +313,18 @@ namespace GmodNET
             push_bool(ptr, tmp);
         }
 
-        public void PushCFunction(CFuncManagedDelegate managed_function)
+        public void PushCFunction(CFuncManagedDelegate managed_function, bool use_safe_error_wrapper = true)
         {
             IntPtr marshaled_function = Marshal.GetFunctionPointerForDelegate<CFuncManagedDelegate>(managed_function);
 
-            push_c_function(ptr, marshaled_function);
+            if(use_safe_error_wrapper)
+            {
+                push_c_function_safe(ptr, marshaled_function);
+            }
+            else
+            {
+                push_c_function(ptr, marshaled_function);
+            }
         }
 
         public void PushCFunction(IntPtr native_func_ptr)

--- a/gm_dotnet_managed/GmodNET/LuaInterop.cs
+++ b/gm_dotnet_managed/GmodNET/LuaInterop.cs
@@ -117,6 +117,8 @@ namespace GmodNET
 
         static internal Func<IntPtr, int, double> check_number;
 
+        static internal Action<IntPtr, IntPtr> push_c_function_safe;
+
         internal static ILua ExtructLua(IntPtr lua_state)
         { 
             IntPtr tmp_ptr = LuaInterop.get_iluabase_from_the_lua_state(lua_state);

--- a/gm_dotnet_managed/GmodNET/LuaInterop.cs
+++ b/gm_dotnet_managed/GmodNET/LuaInterop.cs
@@ -117,7 +117,7 @@ namespace GmodNET
 
         static internal Func<IntPtr, int, double> check_number;
 
-        static internal Action<IntPtr, IntPtr> push_c_function_safe;
+        static internal Action<IntPtr, IntPtr, IntPtr> push_c_function_safe;
 
         internal static ILua ExtructLua(IntPtr lua_state)
         { 

--- a/gm_dotnet_managed/GmodNET/Startup.cs
+++ b/gm_dotnet_managed/GmodNET/Startup.cs
@@ -144,7 +144,7 @@ namespace GmodNET
 
                     LuaInterop.check_number = CreateNativeCaller<Func<IntPtr, int, double>>(params_from_native_code[53]);
 
-                    LuaInterop.push_c_function_safe = CreateNativeCaller<Action<IntPtr, IntPtr>>(params_from_native_code[54]);
+                    LuaInterop.push_c_function_safe = CreateNativeCaller<Action<IntPtr, IntPtr, IntPtr>>(params_from_native_code[54]);
                 }
                 FirstRun = false;
             }

--- a/gm_dotnet_managed/GmodNET/Startup.cs
+++ b/gm_dotnet_managed/GmodNET/Startup.cs
@@ -34,7 +34,7 @@ namespace GmodNET
             {
                 unsafe
                 {
-                    Span<IntPtr> params_from_native_code = new Span<IntPtr>((void*)param, 54);
+                    Span<IntPtr> params_from_native_code = new Span<IntPtr>((void*)param, 55);
 
                     LuaInterop.top = CreateNativeCaller<Func<IntPtr, int>>(params_from_native_code[0]);
 
@@ -143,6 +143,8 @@ namespace GmodNET
                     LuaInterop.check_string = CreateNativeCaller<Func<IntPtr, int, IntPtr, IntPtr>>(params_from_native_code[52]);
 
                     LuaInterop.check_number = CreateNativeCaller<Func<IntPtr, int, double>>(params_from_native_code[53]);
+
+                    LuaInterop.push_c_function_safe = CreateNativeCaller<Action<IntPtr, IntPtr>>(params_from_native_code[54]);
                 }
                 FirstRun = false;
             }

--- a/gm_dotnet_managed/Tests/GetCFunctionTest.cs
+++ b/gm_dotnet_managed/Tests/GetCFunctionTest.cs
@@ -1,0 +1,64 @@
+﻿using GmodNET.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace Tests
+{
+    // Tests ILua.GetCFunction
+    public class GetCFunctionTest : ITest
+    {
+        int random_int;
+        CFuncManagedDelegate test_func;
+        TaskCompletionSource<bool> taskCompletion;
+        GetILuaFromLuaStatePointer lua_extructor;
+
+        public GetCFunctionTest()
+        {
+            random_int = new Random().Next(0, 100);
+            taskCompletion = new TaskCompletionSource<bool>();
+            test_func = (lua_state) =>
+            {
+                return random_int;
+            };
+        }
+
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        {
+            this.lua_extructor = lua_extructor;
+
+            try
+            {
+                lua.PushCFunction(test_func, false);
+                IntPtr pointer_to_test_func = lua.GetCFunction(-1);
+                lua.Pop(1);
+
+                CFuncManagedDelegate received_func = Marshal.GetDelegateForFunctionPointer<CFuncManagedDelegate>(pointer_to_test_func);
+                int new_int = received_func(IntPtr.Zero);
+
+                if(new_int != random_int)
+                {
+                    throw new GetCFunctionTestException("Return number is invalid");
+                }
+
+                taskCompletion.TrySetResult(true);
+            }
+            catch(Exception e)
+            {
+                taskCompletion.TrySetException(new Exception[] { e });
+            }
+
+            return taskCompletion.Task;
+        }
+    }
+
+    public class GetCFunctionTestException : Exception
+    {
+        public GetCFunctionTestException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/gm_dotnet_managed/Tests/PushCFunctionUnsafe.cs
+++ b/gm_dotnet_managed/Tests/PushCFunctionUnsafe.cs
@@ -1,0 +1,66 @@
+﻿using GmodNET.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    // This test pushes Managed C Function delegate without safe wrapper and runs it
+    public class PushCFunctionUnsafe : ITest
+    {
+        double random_double;
+        GetILuaFromLuaStatePointer lua_extructor;
+        TaskCompletionSource<bool> taskCompletion;
+        CFuncManagedDelegate func_to_push;
+
+        public PushCFunctionUnsafe()
+        {
+            Random rand = new Random();
+            random_double = rand.NextDouble();
+            taskCompletion = new TaskCompletionSource<bool>();
+            func_to_push = (lua_state_pointer) =>
+            {
+                ILua lua =lua_extructor(lua_state_pointer);
+
+                lua.PushNumber(this.random_double);
+
+                return 1;
+            };
+        }
+
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        {
+            this.lua_extructor = lua_extructor;
+
+            try
+            {
+                lua.PushCFunction(func_to_push, false);
+                lua.MCall(0, 1);
+                double received_double = lua.GetNumber(-1);
+                lua.Pop(1);
+
+                if(received_double != random_double)
+                {
+                    throw new PushCFunctionUnsafeException("Received double is invalid");
+                }
+
+                taskCompletion.TrySetResult(true);
+            }
+            catch(Exception e)
+            {
+                taskCompletion.TrySetException(new Exception[] { e });
+            }
+
+            return taskCompletion.Task;
+        }
+    }
+
+    public class PushCFunctionUnsafeException : Exception
+    {
+        public PushCFunctionUnsafeException(string message) : base(message)
+        {
+            
+        }
+    }
+}

--- a/gm_dotnet_managed/Tests/ThrowLuaErrorFromManagedCode.cs
+++ b/gm_dotnet_managed/Tests/ThrowLuaErrorFromManagedCode.cs
@@ -23,9 +23,9 @@ namespace Tests
             {
                 ILua lua = lua_extructor(lua_state);
 
-                lua.PushString(error_message);
+                throw new GmodLuaException(2, error_message);
 
-                return -1;
+                return 0;
             };
         }
 
@@ -36,7 +36,10 @@ namespace Tests
             try
             {
                 lua.PushCFunction(function_to_throw_error);
-                lua.PCall(0, 0, 0);
+                if(lua.PCall(0, 0, 0) == 0)
+                {
+                    throw new ThrowLuaErrorFromManagedCodeException("Exception was not thrown");
+                }
                 string received_string = lua.GetString(-1);
                 lua.Pop(1);
 

--- a/gm_dotnet_managed/Tests/ThrowLuaErrorFromManagedCode.cs
+++ b/gm_dotnet_managed/Tests/ThrowLuaErrorFromManagedCode.cs
@@ -1,0 +1,68 @@
+﻿using GmodNET.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    // This test checks if we are able to throw Lua errors from managed code.
+    public class ThrowLuaErrorFromManagedCode : ITest
+    {
+        string error_message;
+        CFuncManagedDelegate function_to_throw_error;
+        TaskCompletionSource<bool> taskCompletion;
+        GetILuaFromLuaStatePointer lua_extructor;
+
+        public ThrowLuaErrorFromManagedCode()
+        {
+            taskCompletion = new TaskCompletionSource<bool>();
+            error_message = Guid.NewGuid().ToString();
+
+            function_to_throw_error = (lua_state) =>
+            {
+                ILua lua = lua_extructor(lua_state);
+
+                lua.PushString(error_message);
+
+                return -1;
+            };
+        }
+
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        {
+            this.lua_extructor = lua_extructor;
+
+            try
+            {
+                lua.PushCFunction(function_to_throw_error);
+                lua.PCall(0, 0, 0);
+                string received_string = lua.GetString(-1);
+                lua.Pop(1);
+
+                if(received_string != error_message)
+                {
+                    throw new ThrowLuaErrorFromManagedCodeException("Error message is invalid");
+                }
+                else
+                {
+                    taskCompletion.TrySetResult(true);
+                }
+            }
+            catch(Exception e)
+            {
+                taskCompletion.TrySetException(new Exception[] { e });
+            }
+
+            return taskCompletion.Task;
+        }
+    }
+
+    public class ThrowLuaErrorFromManagedCodeException : Exception
+    {
+        public ThrowLuaErrorFromManagedCodeException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/gm_dotnet_native/src/LuaAPIExposure.cpp
+++ b/gm_dotnet_native/src/LuaAPIExposure.cpp
@@ -375,17 +375,18 @@ int ClosureSafeWrapper(lua_State * luaState)
     {
         const char * error_msg = lua->GetString(-1);
         lua->ThrowError(error_msg);
-        return arg_ret_num;
+        return 0;
     }
     else
     {
         return arg_ret_num;
     }
 }
-void export_push_c_function_safe(GarrysMod::Lua::ILuaBase * lua, GarrysMod::Lua::CFunc val)
+void export_push_c_function_safe(GarrysMod::Lua::ILuaBase * lua, GarrysMod::Lua::CFunc safe_wrapper, GarrysMod::Lua::CFunc val)
 {
+    lua->PushCFunction(safe_wrapper);
     lua->PushCFunction(val);
-    lua->PushCClosure(ClosureSafeWrapper, 1);
+    lua->PushCClosure(ClosureSafeWrapper, 2);
 }
 
 

--- a/gm_dotnet_native/src/LuaAPIExposure.cpp
+++ b/gm_dotnet_native/src/LuaAPIExposure.cpp
@@ -361,3 +361,31 @@ double export_check_number(ILuaBase * lua, int iStackPos)
     return lua->CheckNumber(iStackPos);
 }
 
+// ClosureSafeWrapper is used internally in export_push_c_function_safe
+int ClosureSafeWrapper(lua_State * luaState)
+{
+    ILuaBase * lua = luaState->luabase;
+    //Get actual function pointer form upvalue pseudoindex
+    CFunc func_ptr = lua->GetCFunction(-10003);
+
+    //Call func_ptr
+    int arg_ret_num = func_ptr(luaState);
+
+    if(arg_ret_num < 0)
+    {
+        const char * error_msg = lua->GetString(-1);
+        lua->ThrowError(error_msg);
+        return arg_ret_num;
+    }
+    else
+    {
+        return arg_ret_num;
+    }
+}
+void export_push_c_function_safe(GarrysMod::Lua::ILuaBase * lua, GarrysMod::Lua::CFunc val)
+{
+    lua->PushCFunction(val);
+    lua->PushCClosure(ClosureSafeWrapper, 1);
+}
+
+

--- a/gm_dotnet_native/src/LuaAPIExposure.h
+++ b/gm_dotnet_native/src/LuaAPIExposure.h
@@ -332,6 +332,6 @@ double export_check_number(GarrysMod::Lua::ILuaBase * lua, int iStackPos);
 /// Pushes the safe wrapped C-Fucntion as CClosure
 /// \param lua ILuaBase pointer
 /// \param val function to push on stack
-void export_push_c_function_safe(GarrysMod::Lua::ILuaBase * lua, GarrysMod::Lua::CFunc val);
+void export_push_c_function_safe(GarrysMod::Lua::ILuaBase * lua, GarrysMod::Lua::CFunc safe_wrapper, GarrysMod::Lua::CFunc val);
 
 #endif //GM_DOTNET_NATIVE_LUAAPIEXPOSURE_H

--- a/gm_dotnet_native/src/LuaAPIExposure.h
+++ b/gm_dotnet_native/src/LuaAPIExposure.h
@@ -329,4 +329,9 @@ const char * export_check_string(GarrysMod::Lua::ILuaBase * lua, int iStackPos, 
 /// \return number from the stack
 double export_check_number(GarrysMod::Lua::ILuaBase * lua, int iStackPos);
 
+/// Pushes the safe wrapped C-Fucntion as CClosure
+/// \param lua ILuaBase pointer
+/// \param val function to push on stack
+void export_push_c_function_safe(GarrysMod::Lua::ILuaBase * lua, GarrysMod::Lua::CFunc val);
+
 #endif //GM_DOTNET_NATIVE_LUAAPIEXPOSURE_H

--- a/gm_dotnet_native/src/gm_dotnet.cpp
+++ b/gm_dotnet_native/src/gm_dotnet.cpp
@@ -210,7 +210,8 @@ GMOD_MODULE_OPEN()
             (void*)export_raw_set,
             (void*)export_push_user_data,
             (void*)export_check_string,
-            (void*)export_check_number
+            (void*)export_check_number,
+            (void*)export_push_c_function_safe
     };
 
     cleanup_delegate = managed_delegate(LUA, maj_ver, min_ver, misc_ver, params_to_managed_code);


### PR DESCRIPTION
1. Managed functions can throw Lua errors as managed exceptions.

2. `ILua.GetCFunction` test added. See issue #11.