### PR TITLE
Added types methods with TYPES type args to ILua

### DIFF
--- a/gm_dotnet_managed/GmodNET.API/ILua.cs
+++ b/gm_dotnet_managed/GmodNET.API/ILua.cs
@@ -211,17 +211,30 @@ namespace GmodNET.API
         /// <returns></returns>
         public bool IsType(int iStackPos, int iType);
         /// <summary>
+        /// Returns true if the value at iStackPos is of the given type.
+        /// </summary>
+        /// <param name="iStackPos">Position of value to check type of</param>
+        /// <param name="type">Type</param>
+        /// <returns></returns>
+        public bool IsType(int iStackPos, TYPES type);
+        /// <summary>
         /// Returns the type of the value at iStackPos.
         /// </summary>
         /// <param name="iStackPos"></param>
         /// <returns></returns>
         public int GetType(int iStackPos);
         /// <summary>
-        /// Returns the name associated with the given type ID.
+        /// Returns the name associated with the given type ID. Doesn't work with user-defined types.
         /// </summary>
         /// <param name="iType">Type index</param>
         /// <returns></returns>
         public string GetTypeName(int iType);
+        /// <summary>
+        /// Returns the name associated with the given type.
+        /// </summary>
+        /// <param name="type">Type</param>
+        /// <returns></returns>
+        public string GetTypeName(TYPES type);
         /// <summary>
         /// Returns the length of the object at iStackPos.
         /// </summary>
@@ -265,9 +278,15 @@ namespace GmodNET.API
         /// <summary>
         /// Pushes the metatable associated with the given type.
         /// </summary>
-        /// <param name="iType">Type which contains metatable</param>
+        /// <param name="iType">Index of the type which metatable to push</param>
         /// <returns>Success indicator</returns>
         public bool PushMetaTable(int iType);
+        /// <summary>
+        /// Pushes the metatable associated with the given type.
+        /// </summary>
+        /// <param name="type">Type which metatable to push</param>
+        /// <returns>Success indicator</returns>
+        public bool PushMetaTable(TYPES type);
         /// <summary>
         /// Creates a new UserData of type iType that references the given data.
         /// </summary>

--- a/gm_dotnet_managed/GmodNET/Lua.cs
+++ b/gm_dotnet_managed/GmodNET/Lua.cs
@@ -415,6 +415,11 @@ namespace GmodNET
             }
         }
 
+        public bool IsType(int iStackPos, TYPES type)
+        {
+            return this.IsType(iStackPos, (int)type);
+        }
+
         public int GetType(int iStackPos)
         {
             if (iStackPos == 0)
@@ -436,6 +441,11 @@ namespace GmodNET
 
                 return Encoding.UTF8.GetString((byte*)c_str, len);
             }
+        }
+
+        public string GetTypeName(TYPES type)
+        {
+            return this.GetTypeName((int)type);
         }
 
         public int ObjLen(int iStackPos)
@@ -523,6 +533,11 @@ namespace GmodNET
             {
                 return true;
             }
+        }
+
+        public bool PushMetaTable(TYPES type)
+        {
+            return this.PushMetaTable((int)type);
         }
 
         public void PushUserType(IntPtr data_pointer, int iType)

--- a/gm_dotnet_managed/Tests/GetTypeNameEnum.cs
+++ b/gm_dotnet_managed/Tests/GetTypeNameEnum.cs
@@ -1,0 +1,48 @@
+﻿using GmodNET.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    // Tests ILua.GetTypeName(TYPES) method
+    public class GetTypeNameEnum : ITest
+    {
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        {
+            TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
+
+            try
+            {
+                if(lua.GetTypeName(TYPES.NIL) != "nil")
+                {
+                    throw new Exception("GetTypeName returned incorrect name for the type NIL");
+                }
+
+                if(lua.GetTypeName(TYPES.STRING) != "string")
+                {
+                    throw new Exception("GetTypeName returned incorrect name for the type STRING");
+                }
+
+                if(lua.GetTypeName(TYPES.NUMBER) != "number")
+                {
+                    throw new Exception("GetTypeName returned incorrect name for the type NUMBER");
+                }
+
+                if(lua.GetTypeName(TYPES.BOOL) != "bool")
+                {
+                    throw new Exception("GetTypeName returned incorrect name for the type BOOL");
+                }
+
+                taskCompletion.TrySetResult(true);
+            }
+            catch(Exception e)
+            {
+                taskCompletion.TrySetException(new Exception[] { e });
+            }
+
+            return taskCompletion.Task;
+        }
+    }
+}

--- a/gm_dotnet_managed/Tests/IsTypeEnum.cs
+++ b/gm_dotnet_managed/Tests/IsTypeEnum.cs
@@ -17,7 +17,7 @@ namespace Tests
             {
                 lua.PushNumber(1);
 
-                lua.PushString("I love Dima");
+                lua.PushString("I love Dima. Dima is the best.");
 
                 lua.PushBool(true);
 

--- a/gm_dotnet_managed/Tests/IsTypeEnum.cs
+++ b/gm_dotnet_managed/Tests/IsTypeEnum.cs
@@ -1,0 +1,58 @@
+﻿using GmodNET.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    // Test for ILua.IsType(TYPES) method
+    public class IsTypeEnum : ITest
+    {
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        {
+            TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
+
+            try
+            {
+                lua.PushNumber(1);
+
+                lua.PushString("I love Dima");
+
+                lua.PushBool(true);
+
+                lua.PushNil();
+
+                if(!lua.IsType(-4, TYPES.NUMBER))
+                {
+                    throw new Exception("IsType returned false on NUMBER type");
+                }
+
+                if(!lua.IsType(-3, TYPES.STRING))
+                {
+                    throw new Exception("IsType returned false on STRING type");
+                }
+
+                if(!lua.IsType(-2, TYPES.BOOL))
+                {
+                    throw new Exception("IsType returned false on BOOL type");
+                }
+
+                if(!lua.IsType(-1, TYPES.NIL))
+                {
+                    throw new Exception("IsType returned false on NIL type");
+                }
+
+                lua.Pop(4);
+
+                taskCompletion.TrySetResult(true);
+            }
+            catch(Exception e)
+            {
+                taskCompletion.TrySetException(new Exception[] { e });
+            }
+
+            return taskCompletion.Task;
+        }
+    }
+}


### PR DESCRIPTION
Added types methods with TYPES type args to ILua: `IsType`, `GetTypeName`, `PushMetaTable`. See issue #30.