### PR TITLE
New customizable native library resolution process

### DIFF
--- a/gm_dotnet_managed/GmodNET.API/IModule.cs
+++ b/gm_dotnet_managed/GmodNET.API/IModule.cs
@@ -37,7 +37,7 @@ namespace GmodNET.API
         /// <param name="is_serverside">Indicates weather module is loaded serverside</param>
         /// <param name="lua_extructor">This property gets a delegate which helps to get ILua from lua_state native pointer. Needed for ILua.PushCFunction functionality.</param>
         /// <param name="assembly_context">AseemblyLoadContext of this module.</param>
-        public void Load(ILua lua, bool is_serverside, GetILuaFromLuaStatePointer lua_extructor, AssemblyLoadContext assembly_context);
+        public void Load(ILua lua, bool is_serverside, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext assembly_context);
         /// <summary>
         /// Will be called by GmodNET on module unload. In this method module must cleanup and unregister with Garry's Mod native/lua data.
         /// </summary>

--- a/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
@@ -5,14 +5,58 @@ using System.Runtime.Loader;
 
 namespace GmodNET.API
 {
+    /// <summary>
+    /// An extension of <see cref="AssemblyLoadContext" /> class with GmodNET specific features.
+    /// </summary>
     public abstract class ModuleAssemblyLoadContext : AssemblyLoadContext
     {
+        /// <summary>
+        /// Get associated module name.
+        /// </summary>
         public abstract string ModuleName {get; }
 
+
+        /// <summary>
+        /// Get current custom native library resolver delegate.
+        /// </summary>
         public abstract Func<ModuleAssemblyLoadContext, string, IntPtr> CustomNativeLibraryResolver {get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModuleAssemblyLoadContext" /> class with a value that indicates whether unloading is enabled.
+        /// </summary>
+        /// <param name="isCollectible"></param>
         public ModuleAssemblyLoadContext(bool isCollectible) : base(isCollectible: isCollectible){ }
 
+        /// <summary>
+        /// Sets <paramref name="resolver"/> as new custom native library resolution middleware for the current instance of <see cref="ModuleAssemblyLoadContext"/>.
+        /// </summary>
+        /// <param name="resolver">
+        /// A new custom native library resolver delegate. This delegate takes an instance of <see cref="ModuleAssemblyLoadContext"/> in which native resolution process
+        /// is taking place and the name of the native library to resolve as parameters. The delegate should return an OS handle (as IntPtr) for the loaded native library.
+        /// If the delegate returnes <see cref="IntPtr.Zero"/> then the instance of <see cref="ModuleAssemblyLoadContext"/> will try to resolve the native library using the
+        /// default resolution process.
+        /// Can be set to null to return the instance of <see cref="ModuleAssemblyLoadContext"/> to the default native library resolution process.
+        /// </param>
+        /// <example>
+        /// <code>
+        /// public void Load(ILua lua, bool is_serverside, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext assembly_context)
+        /// {
+        ///     assembly_context.SetCustomNativeLibraryResolver((context, library_name) =>
+        ///     {
+        ///         if(library_name == "some_special_library_for_which_we_want_to_customize_resolution_process")
+        ///         {
+        ///             return System.Runtime.InteropServices.NativeLibrary.Load("path/to/that/special/library");
+        ///         }
+        ///         else
+        ///         {
+        ///             // By returning IntPtr.Zero here we allow GmodNET runtime to use the default resolution process
+        ///             // for libraries with different names.
+        ///             return IntPtr.Zero;
+        ///         }
+        ///     });
+        /// }
+        /// </code>
+        /// </example>
         public abstract void SetCustomNativeLibraryResolver(Func<ModuleAssemblyLoadContext, string, IntPtr> resolver);
     }
 }

--- a/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
@@ -12,5 +12,7 @@ namespace GmodNET.API
         public abstract Func<ModuleAssemblyLoadContext, string, IntPtr> CustomNativeLibraryResolver {get; }
 
         public ModuleAssemblyLoadContext(bool isCollectible) : base(isCollectible: isCollectible){ }
+
+        public abstract void SetCustomNativeLibraryResolver(Func<ModuleAssemblyLoadContext, string, IntPtr> resolver);
     }
 }

--- a/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.Loader;
+
+namespace GmodNET.API
+{
+    public abstract class ModuleAssemblyLoadContext : AssemblyLoadContext
+    {
+        public abstract string ModuleName {get; }
+
+        public ModuleAssemblyLoadContext() : base(isCollectible: true){ }
+    }
+}

--- a/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Runtime.Loader;
+using System.Reflection;
 
 namespace GmodNET.API
 {
@@ -13,8 +14,9 @@ namespace GmodNET.API
         /// <summary>
         /// Get associated module name.
         /// </summary>
-        public abstract string ModuleName {get; }
+        public virtual string ModuleName => moduleName;
 
+        string moduleName;
 
         /// <summary>
         /// Get current custom native library resolver delegate.
@@ -24,8 +26,12 @@ namespace GmodNET.API
         /// <summary>
         /// Initializes a new instance of the <see cref="ModuleAssemblyLoadContext" /> class with a value that indicates whether unloading is enabled.
         /// </summary>
-        /// <param name="isCollectible"></param>
-        public ModuleAssemblyLoadContext(bool isCollectible) : base(isCollectible: isCollectible){ }
+        /// <param name="isCollectible"><c>true</c> to enable <see cref="AssemblyLoadContext.Unload()"/>; otherwise, <c>false</c>. </param>
+        /// <param name="module_name">The name of the corresponding module.</param>
+        public ModuleAssemblyLoadContext(string module_name, bool isCollectible) : base(isCollectible: isCollectible)
+        { 
+            moduleName = module_name;
+        }
 
         /// <summary>
         /// Sets <paramref name="resolver"/> as new custom native library resolution middleware for the current instance of <see cref="ModuleAssemblyLoadContext"/>.

--- a/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
@@ -9,6 +9,6 @@ namespace GmodNET.API
     {
         public abstract string ModuleName {get; }
 
-        public ModuleAssemblyLoadContext() : base(isCollectible: true){ }
+        public ModuleAssemblyLoadContext(bool isCollectible) : base(isCollectible: isCollectible){ }
     }
 }

--- a/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET.API/ModuleAssemblyLoadContext.cs
@@ -9,6 +9,8 @@ namespace GmodNET.API
     {
         public abstract string ModuleName {get; }
 
+        public abstract Func<ModuleAssemblyLoadContext, string, IntPtr> CustomNativeLibraryResolver {get; }
+
         public ModuleAssemblyLoadContext(bool isCollectible) : base(isCollectible: isCollectible){ }
     }
 }

--- a/gm_dotnet_managed/GmodNET/GloabalContext.cs
+++ b/gm_dotnet_managed/GmodNET/GloabalContext.cs
@@ -307,7 +307,7 @@ namespace GmodNET
                         {
                             if(info.PublicKey == null || info.PublicKey == String.Empty)
                             {
-                                ModuleAssemblyLoadContext context = new ModuleAssemblyLoadContext(d.Name); 
+                                GmodNetModuleAssemblyLoadContext context = new GmodNetModuleAssemblyLoadContext(d.Name); 
 
                                 Assembly module_asm = context.LoadFromAssemblyPath(d.FullName + "/" + d.Name + ".dll");
 
@@ -412,7 +412,7 @@ namespace GmodNET
                                     {
                                         try
                                         {
-                                            ModuleAssemblyLoadContext module_context = new ModuleAssemblyLoadContext(d.Name);
+                                            GmodNetModuleAssemblyLoadContext module_context = new GmodNetModuleAssemblyLoadContext(d.Name);
 
                                             Assembly module_asm = module_context.LoadFromAssemblyPath(d.FullName + "/" + d.Name + ".dll");
 
@@ -694,7 +694,7 @@ namespace GmodNET
                     {
                         try
                         {
-                            ModuleAssemblyLoadContext local_context = new ModuleAssemblyLoadContext(d.Name);
+                            GmodNetModuleAssemblyLoadContext local_context = new GmodNetModuleAssemblyLoadContext(d.Name);
 
                             Assembly module_asm = local_context.LoadFromAssemblyPath(d.GetFiles().First((f) => f.Name == d.Name + ".dll").FullName);
 
@@ -980,10 +980,10 @@ namespace GmodNET
 
     internal class ModuleHolder
     {
-        internal ModuleAssemblyLoadContext context;
+        internal GmodNetModuleAssemblyLoadContext context;
         internal List<IModule> modules;
 
-        internal ModuleHolder(ModuleAssemblyLoadContext context, List<IModule> modules)
+        internal ModuleHolder(GmodNetModuleAssemblyLoadContext context, List<IModule> modules)
         {
             this.context = context;
             this.modules = modules;

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -84,7 +84,14 @@ namespace GmodNET
                 }
                 else
                 {
-                    return this.LoadUnmanagedDllFromPath(unmanaged_dep_path);
+                    try
+                    {
+                        return this.LoadUnmanagedDllFromPath(unmanaged_dep_path);
+                    }
+                    catch
+                    {
+                        return IntPtr.Zero;
+                    }
                 }
             }
         }

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -40,6 +40,7 @@ namespace GmodNET
         {
             this.module_name = module_name;
             resolver = new AssemblyDependencyResolver("garrysmod/lua/bin/Modules/"+module_name+"/"+module_name+".dll");
+            customNativeLibraryResolver = null;
         }
 
         protected override System.Reflection.Assembly Load(System.Reflection.AssemblyName assemblyName)

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace GmodNET
 {
-    internal class ModuleAssemblyLoadContext : AssemblyLoadContext
+    internal class GmodNetModuleAssemblyLoadContext : AssemblyLoadContext
     {
         private AssemblyDependencyResolver resolver;
         private string module_name;
@@ -21,7 +21,7 @@ namespace GmodNET
             }
         }
         
-        internal ModuleAssemblyLoadContext(string module_name) : base(isCollectible: true)
+        internal GmodNetModuleAssemblyLoadContext(string module_name) : base(isCollectible: true)
         {
             this.module_name = module_name;
             resolver = new AssemblyDependencyResolver("garrysmod/lua/bin/Modules/"+module_name+"/"+module_name+".dll");

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -30,6 +30,11 @@ namespace GmodNET
                 return customNativeLibraryResolver;
             }
         }
+
+        public override void SetCustomNativeLibraryResolver(Func<ModuleAssemblyLoadContext, string, IntPtr> resolver)
+        {
+            customNativeLibraryResolver = resolver;
+        }
         
         internal GmodNetModuleAssemblyLoadContext(string module_name) : base(isCollectible: true)
         {

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -13,6 +13,7 @@ namespace GmodNET
     {
         private AssemblyDependencyResolver resolver;
         private string module_name;
+        private Func<ModuleAssemblyLoadContext, string, IntPtr> customNativeLibraryResolver;
 
         public override string ModuleName
         { 
@@ -22,7 +23,7 @@ namespace GmodNET
             }
         }
         
-        internal GmodNetModuleAssemblyLoadContext(string module_name) : base()
+        internal GmodNetModuleAssemblyLoadContext(string module_name) : base(isCollectible: true)
         {
             this.module_name = module_name;
             resolver = new AssemblyDependencyResolver("garrysmod/lua/bin/Modules/"+module_name+"/"+module_name+".dll");

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -5,15 +5,16 @@ using System.Runtime.Loader;
 using System.IO;
 using System.Reflection;
 using System.Linq;
+using GmodNET.API;
 
 namespace GmodNET
 {
-    internal class GmodNetModuleAssemblyLoadContext : AssemblyLoadContext
+    internal class GmodNetModuleAssemblyLoadContext : ModuleAssemblyLoadContext
     {
         private AssemblyDependencyResolver resolver;
         private string module_name;
 
-        internal string ModuleName
+        public override string ModuleName
         { 
             get
             {
@@ -21,7 +22,7 @@ namespace GmodNET
             }
         }
         
-        internal GmodNetModuleAssemblyLoadContext(string module_name) : base(isCollectible: true)
+        internal GmodNetModuleAssemblyLoadContext(string module_name) : base()
         {
             this.module_name = module_name;
             resolver = new AssemblyDependencyResolver("garrysmod/lua/bin/Modules/"+module_name+"/"+module_name+".dll");

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -63,15 +63,29 @@ namespace GmodNET
 
         protected override IntPtr LoadUnmanagedDll (string unmanagedDllName)
         {
-            string unmanaged_dep_path = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+            IntPtr lib_pointer = IntPtr.Zero;
 
-            if(unmanaged_dep_path == null)
+            if(customNativeLibraryResolver != null)
             {
-                return IntPtr.Zero;
+                lib_pointer = customNativeLibraryResolver(this, unmanagedDllName);
+            }
+
+            if(lib_pointer != IntPtr.Zero)
+            {
+                return lib_pointer;
             }
             else
             {
-                return this.LoadUnmanagedDllFromPath(unmanaged_dep_path);
+                string unmanaged_dep_path = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+
+                if(unmanaged_dep_path == null)
+                {
+                    return IntPtr.Zero;
+                }
+                else
+                {
+                    return this.LoadUnmanagedDllFromPath(unmanaged_dep_path);
+                }
             }
         }
     }

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -22,6 +22,14 @@ namespace GmodNET
                 return module_name;
             }
         }
+
+        public override Func<ModuleAssemblyLoadContext, string, IntPtr> CustomNativeLibraryResolver
+        {
+            get
+            {
+                return customNativeLibraryResolver;
+            }
+        }
         
         internal GmodNetModuleAssemblyLoadContext(string module_name) : base(isCollectible: true)
         {

--- a/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
+++ b/gm_dotnet_managed/GmodNET/GmodNetModuleAssemblyLoadContext.cs
@@ -36,7 +36,7 @@ namespace GmodNET
             customNativeLibraryResolver = resolver;
         }
         
-        internal GmodNetModuleAssemblyLoadContext(string module_name) : base(isCollectible: true)
+        internal GmodNetModuleAssemblyLoadContext(string module_name) : base(module_name: module_name, isCollectible: true)
         {
             this.module_name = module_name;
             resolver = new AssemblyDependencyResolver("garrysmod/lua/bin/Modules/"+module_name+"/"+module_name+".dll");

--- a/gm_dotnet_managed/Tests/AspNetCoreTest.cs
+++ b/gm_dotnet_managed/Tests/AspNetCoreTest.cs
@@ -28,7 +28,7 @@ namespace Tests
             randomString = Guid.NewGuid().ToString();
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             try
             {

--- a/gm_dotnet_managed/Tests/CheckType.cs
+++ b/gm_dotnet_managed/Tests/CheckType.cs
@@ -23,7 +23,7 @@ namespace Tests
             };
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             try
             {

--- a/gm_dotnet_managed/Tests/CreateMetaTable.cs
+++ b/gm_dotnet_managed/Tests/CreateMetaTable.cs
@@ -27,7 +27,7 @@ namespace Tests
             MetaToStringDelegate = MetaToString;
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/CreateMetaTableTest.cs
+++ b/gm_dotnet_managed/Tests/CreateMetaTableTest.cs
@@ -32,7 +32,7 @@ namespace Tests
             };
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/CreateTable.cs
+++ b/gm_dotnet_managed/Tests/CreateTable.cs
@@ -9,7 +9,7 @@ namespace Tests
     // This test creates a new table, populates it with some data, and tries to get the data back
     public class CreateTable : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
+++ b/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
@@ -26,7 +26,7 @@ namespace Tests
                         }
                         else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                         {
-                            return NativeLibrary.Load("dl");
+                            return NativeLibrary.Load("libdl.so");
                         }
                         else
                         {

--- a/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
+++ b/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
@@ -24,9 +24,13 @@ namespace Tests
                         {
                             return NativeLibrary.Load("Kernel32");
                         }
-                        else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                         {
                             return NativeLibrary.Load("libdl.so");
+                        }
+                        else if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        {
+                            return NativeLibrary.Load("libdl.dylib");
                         }
                         else
                         {

--- a/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
+++ b/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
@@ -1,0 +1,61 @@
+﻿using GmodNET.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace Tests
+{
+    // Tests that we can customize native library resolution process from within a module
+    public class CustomNativeLoadProcessA : ITest
+    {
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext assembly_context)
+        {
+            TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
+
+            try
+            {
+                assembly_context.SetCustomNativeLibraryResolver((context, lib_name) =>
+                {
+                    if(lib_name == "SomeRandomLibraryName")
+                    {
+                        if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            return NativeLibrary.Load("Kernel32");
+                        }
+                        else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        {
+                            return NativeLibrary.Load("libdl");
+                        }
+                        else
+                        {
+                            return IntPtr.Zero;
+                        }
+                    }
+                    else
+                    {
+                        return IntPtr.Zero;
+                    }
+                });
+
+                IntPtr test_lib_handle = NativeLibrary.Load("SomeRandomLibraryName");
+
+                if(test_lib_handle == IntPtr.Zero)
+                {
+                    throw new Exception("Native library handle is zero");
+                }
+
+                assembly_context.SetCustomNativeLibraryResolver(null);
+
+                taskCompletion.TrySetResult(true);
+            }
+            catch(Exception e)
+            { 
+                taskCompletion.TrySetException(new Exception[] { e });
+            }
+
+            return taskCompletion.Task;
+        }
+    }
+}

--- a/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
+++ b/gm_dotnet_managed/Tests/CustomNativeLoadProcessA.cs
@@ -26,7 +26,7 @@ namespace Tests
                         }
                         else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                         {
-                            return NativeLibrary.Load("libdl");
+                            return NativeLibrary.Load("dl");
                         }
                         else
                         {

--- a/gm_dotnet_managed/Tests/CustomNativeLoadProcessB.cs
+++ b/gm_dotnet_managed/Tests/CustomNativeLoadProcessB.cs
@@ -18,7 +18,14 @@ namespace Tests
             {
                 try
                 {
-                    IntPtr test_lib_handle = NativeLibrary.Load("SomeRandomLibraryName");
+                    if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        LoadLibraryA("Kernel32");
+                    }
+                    else
+                    {
+                        dlopen("libdl", 0);
+                    }
                 }
                 catch(DllNotFoundException e)
                 {
@@ -32,5 +39,11 @@ namespace Tests
 
             return taskCompletion.Task;
         }
+
+        [DllImport("SomeRandomLibraryName", CharSet = CharSet.Ansi)]
+        public static extern IntPtr LoadLibraryA(string lib_name);
+
+        [DllImport("SomeRandomLibraryName")]
+        public static extern IntPtr dlopen(string lib_name, int flag);
     }
 }

--- a/gm_dotnet_managed/Tests/CustomNativeLoadProcessB.cs
+++ b/gm_dotnet_managed/Tests/CustomNativeLoadProcessB.cs
@@ -1,0 +1,36 @@
+﻿using GmodNET.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace Tests
+{
+    // A continuation of CustomNativeLoadProcessA. Tests that native resolution process can be reverted back to default.
+    public class CustomNativeLoadProcessB : ITest
+    {
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext assembly_context)
+        {
+            TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
+
+            try
+            {
+                try
+                {
+                    IntPtr test_lib_handle = NativeLibrary.Load("SomeRandomLibraryName");
+                }
+                catch(DllNotFoundException e)
+                {
+                    taskCompletion.TrySetResult(true);
+                }
+            }
+            catch(Exception e)
+            {
+                taskCompletion.TrySetException(new Exception[] { e });
+            }
+
+            return taskCompletion.Task;
+        }
+    }
+}

--- a/gm_dotnet_managed/Tests/EqualityTest.cs
+++ b/gm_dotnet_managed/Tests/EqualityTest.cs
@@ -27,7 +27,7 @@ namespace Tests
             };
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/GetCFunctionTest.cs
+++ b/gm_dotnet_managed/Tests/GetCFunctionTest.cs
@@ -25,7 +25,7 @@ namespace Tests
             };
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/GetMetaTableTest.cs
+++ b/gm_dotnet_managed/Tests/GetMetaTableTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     //Test for ILua.GetMetaTable
     public class GetMetaTableTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/GetTableAndRawGet.cs
+++ b/gm_dotnet_managed/Tests/GetTableAndRawGet.cs
@@ -37,7 +37,7 @@ namespace Tests
             };
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/GetTypeNameEnum.cs
+++ b/gm_dotnet_managed/Tests/GetTypeNameEnum.cs
@@ -9,7 +9,7 @@ namespace Tests
     // Tests ILua.GetTypeName(TYPES) method
     public class GetTypeNameEnum : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/ITest.cs
+++ b/gm_dotnet_managed/Tests/ITest.cs
@@ -8,6 +8,6 @@ namespace Tests
 {
     public interface ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor);
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext assembly_context);
     }
 }

--- a/gm_dotnet_managed/Tests/InsertTest.cs
+++ b/gm_dotnet_managed/Tests/InsertTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // Test for ILua.Insert
     public class InsertTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/IsTypeEnum.cs
+++ b/gm_dotnet_managed/Tests/IsTypeEnum.cs
@@ -9,7 +9,7 @@ namespace Tests
     // Test for ILua.IsType(TYPES) method
     public class IsTypeEnum : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/MCallTest.cs
+++ b/gm_dotnet_managed/Tests/MCallTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // This is a test for ILua.MCall
     public class MCallTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/NativeDependencies.cs
+++ b/gm_dotnet_managed/Tests/NativeDependencies.cs
@@ -14,7 +14,7 @@ namespace Tests
         [DllImport("gmodTestLib", EntryPoint = "hello")]
         public static extern int NativeTestFunc(int x);
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/NativeDependencies.cs
+++ b/gm_dotnet_managed/Tests/NativeDependencies.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-using NSec.Cryptography;
+using System.Runtime.InteropServices;
 
 namespace Tests
 {
@@ -11,14 +11,22 @@ namespace Tests
     // libsodium native library
     public class NativeDependencies : ITest
     {
+        [DllImport("gmodTestLib", EntryPoint = "hello")]
+        public static extern int NativeTestFunc(int x);
+
         public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 
             try
             {
-                var blake2_hasher = HashAlgorithm.Blake2b_512;
-                var hash = blake2_hasher.Hash(Encoding.UTF8.GetBytes("Test"));
+                int random_int = new Random().Next(0, 1000);
+                int result = NativeTestFunc(random_int);
+
+                if(result != random_int + 3)
+                {
+                    throw new Exception("NativeTestFunc returned invalid value");
+                }
 
                 taskCompletion.TrySetResult(true);
             }

--- a/gm_dotnet_managed/Tests/NextTest.cs
+++ b/gm_dotnet_managed/Tests/NextTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // Test for ILua.Next
     public class NextTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/NullReferenceTest.cs
+++ b/gm_dotnet_managed/Tests/NullReferenceTest.cs
@@ -7,7 +7,7 @@ namespace Tests
     // This test checks that CoreCLR can catch NullReferenceException (which is important on *nix systems since it uses SIGSEGV handling to detect)
     public class NullReferenceTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/ObjLenTest.cs
+++ b/gm_dotnet_managed/Tests/ObjLenTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // Test for ILua.ObjLen
     public class ObjLenTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/PCallTest.cs
+++ b/gm_dotnet_managed/Tests/PCallTest.cs
@@ -16,7 +16,7 @@ namespace Tests
             taskCompletion = new TaskCompletionSource<bool>();
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             try
             {

--- a/gm_dotnet_managed/Tests/PopTopTest.cs
+++ b/gm_dotnet_managed/Tests/PopTopTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // This test checks that lua.Pop() and lua.Top() work properly
     public class PopTopTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/PushAngle.cs
+++ b/gm_dotnet_managed/Tests/PushAngle.cs
@@ -10,7 +10,7 @@ namespace Tests
     // This test pushes random angle and gets it back
     public class PushAngle : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/PushBool.cs
+++ b/gm_dotnet_managed/Tests/PushBool.cs
@@ -18,7 +18,7 @@ namespace Tests
             uuid = Guid.NewGuid().ToString();
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             task_completion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/PushCClosureTest.cs
+++ b/gm_dotnet_managed/Tests/PushCClosureTest.cs
@@ -35,7 +35,7 @@ namespace Tests
             closure_ptr = Marshal.GetFunctionPointerForDelegate<CFuncManagedDelegate>(closure_del);
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/PushCFunction.cs
+++ b/gm_dotnet_managed/Tests/PushCFunction.cs
@@ -23,7 +23,7 @@ namespace Tests
             TickCounterDelegate = TickCounter;
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/PushCFunctionUnsafe.cs
+++ b/gm_dotnet_managed/Tests/PushCFunctionUnsafe.cs
@@ -29,7 +29,7 @@ namespace Tests
             };
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/PushCallback.cs
+++ b/gm_dotnet_managed/Tests/PushCallback.cs
@@ -27,7 +27,7 @@ namespace Tests
             CallbackDelegate = Callback;
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/PushNumber.cs
+++ b/gm_dotnet_managed/Tests/PushNumber.cs
@@ -11,7 +11,7 @@ namespace Tests
     {
         TaskCompletionSource<bool> taskSource;
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             taskSource = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/PushString.cs
+++ b/gm_dotnet_managed/Tests/PushString.cs
@@ -17,7 +17,7 @@ namespace Tests
             FieldName = Guid.NewGuid().ToString();
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/PushTest.cs
+++ b/gm_dotnet_managed/Tests/PushTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // The ILua.Push test
     public class PushTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/PushVector.cs
+++ b/gm_dotnet_managed/Tests/PushVector.cs
@@ -10,7 +10,7 @@ namespace Tests
     // This test pushes random vector and gets it back
     public class PushVector : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/ReferenceTest.cs
+++ b/gm_dotnet_managed/Tests/ReferenceTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // Test for ILua.ReferenceCreate, ILua.ReferencePush and ILua.ReferenceFree
     public class ReferenceTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/RemoveTest.cs
+++ b/gm_dotnet_managed/Tests/RemoveTest.cs
@@ -9,7 +9,7 @@ namespace Tests
     // Test for ILua.Remove
     public class RemoveTest : ITest
     {
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/SetTableAndRawSet.cs
+++ b/gm_dotnet_managed/Tests/SetTableAndRawSet.cs
@@ -33,7 +33,7 @@ namespace Tests
             };
         }
         
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 

--- a/gm_dotnet_managed/Tests/SpawnEntity.cs
+++ b/gm_dotnet_managed/Tests/SpawnEntity.cs
@@ -24,7 +24,7 @@ namespace Tests
             spawn_func = SpawnFunc;
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/Tests.cs
+++ b/gm_dotnet_managed/Tests/Tests.cs
@@ -145,7 +145,7 @@ namespace Tests
 
                     lua.Log("Starting test " + cur_test_inst.GetType().ToString());
 
-                    Task<bool> cur_test_promise = cur_test_inst.Start(lua, this.lua_extructor);
+                    Task<bool> cur_test_promise = cur_test_inst.Start(lua, this.lua_extructor, current_load_context);
 
                     current_test = new Tuple<ITest, Task<bool>>(cur_test_inst, cur_test_promise);
                 }

--- a/gm_dotnet_managed/Tests/Tests.cs
+++ b/gm_dotnet_managed/Tests/Tests.cs
@@ -22,7 +22,7 @@ namespace Tests
 
         GetILuaFromLuaStatePointer lua_extructor;
 
-        AssemblyLoadContext current_load_context;
+        ModuleAssemblyLoadContext current_load_context;
 
         CFuncManagedDelegate OnTickDelegate;
 
@@ -44,7 +44,7 @@ namespace Tests
             IsEverythingSuccessful = false;
         }
 
-        public void Load(ILua lua, bool is_serverside, GetILuaFromLuaStatePointer lua_extructor, AssemblyLoadContext assembly_context)
+        public void Load(ILua lua, bool is_serverside, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext assembly_context)
         {
             this.lua = lua;
             this.isServerSide = is_serverside;

--- a/gm_dotnet_managed/Tests/Tests.csproj
+++ b/gm_dotnet_managed/Tests/Tests.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSec.Cryptography" Version="20.2.0" />
+    <PackageReference Include="GmodNET.Tests.Native" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/gm_dotnet_managed/Tests/ThrowLuaErrorFromManagedCode.cs
+++ b/gm_dotnet_managed/Tests/ThrowLuaErrorFromManagedCode.cs
@@ -29,7 +29,7 @@ namespace Tests
             };
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             this.lua_extructor = lua_extructor;
 

--- a/gm_dotnet_managed/Tests/UserData.cs
+++ b/gm_dotnet_managed/Tests/UserData.cs
@@ -28,7 +28,7 @@ namespace Tests
             RandomInt3 = rand.Next(0, 10000);
         }
 
-        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor)
+        public Task<bool> Start(ILua lua, GetILuaFromLuaStatePointer lua_extructor, ModuleAssemblyLoadContext _)
         {
             TaskCompletionSource<bool> taskCompletion = new TaskCompletionSource<bool>();
 


### PR DESCRIPTION
Addresses issue #25.

`ModuleAssemblyLoadContext` now exposes a new method `SetCustomNativeLibraryResolver`, which allow modules to add middleware to native libraries resolution process within their corresponding assembly load contexts.