### PR TITLE
fix unpooled message

### DIFF
--- a/lua/autorun/serverside/gm_dotnet_server.lua
+++ b/lua/autorun/serverside/gm_dotnet_server.lua
@@ -1,3 +1,5 @@
+util.AddNetworkString("gmodnet_verify_request")
+
 print("Loading GmodNET serverside...")
 
 require("dotnet")


### PR DESCRIPTION
fix for
```lua
[ERROR] lua/autorun/client/gmod-dot-net-lua-client.0.7.0-alpha.2.24894336.new-load-model.lua:3030: Calling net.Start with unpooled message name! [ http://goo.gl/qcx0y ]
  1. Start - [C]:-1
   2. v - lua/autorun/client/gmod-dot-net-lua-client.0.7.0-alpha.2.24894336.new-load-model.lua:3030
    3. unknown - lua/includes/modules/hook.lua:84
```
https://github.com/GmodNET/GmodDotNet/blob/master/lua/autorun/clientside/gm_dotnet_client.lua#L3030