### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,16 +6,16 @@ labels: bug
 assignees: ''
 ---
 
-**Describe the bug**
+# Describe the bug
 <!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
+# To Reproduce
 <!-- Steps to reproduce the behavior: -->
 
-**Expected behavior**
+# Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Platforms where you've faced the bug**
+# Platforms where you've faced the bug
 - [ ] SRCDS Linux
 
 - [ ] SRCDS Windows

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,11 +6,11 @@ labels: bug
 assignees: ''
 ---
 
-# Describe the bug
+# Bug description
 <!-- A clear and concise description of what the bug is. -->
 
-# To Reproduce
-<!-- Steps to reproduce the behavior: -->
+# Steps to reproduce
+<!-- Instructions on how to reproduce the behavior. -->
 
 # Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,17 +4,16 @@ about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior:
+<!-- Steps to reproduce the behavior: -->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Platforms where you've faced the bug**
 - [ ] SRCDS Linux
@@ -27,5 +26,5 @@ A clear and concise description of what you expected to happen.
 
 - [ ] Garry's Mod macOS
 
-**Additional context**
-Add any other context about the problem here.
+# Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/docs_question.md
+++ b/.github/ISSUE_TEMPLATE/docs_question.md
@@ -6,13 +6,13 @@ labels: documentation
 assignees: ''
 ---
 
-**Describe the problem**
+# Describe the problem
 <!-- What is currently unclear to you? E.g: I can't figure out how to... -->
 
-**Documentation already consulted**
+# Documentation already consulted
 <!-- A list of links to the [documentation](https://docs.gmodnet.xyz/) where you already tried, or expected, to find answers. -->
 
-**Current state of the documentation**
+# Current state of the documentation
 - [ ] The documentation has some information related to my problem.
 - [x] The documentation describes nothing related to my problem.
 - [ ] The documentation has information that could help with my problem, but it is incorrect/incomplete.

--- a/.github/ISSUE_TEMPLATE/docs_question.md
+++ b/.github/ISSUE_TEMPLATE/docs_question.md
@@ -6,17 +6,16 @@ labels: documentation
 assignees: ''
 ---
 
-**What is currently unclear to you? Describe the problem you are experiencing.**
-E.g: I can't figure out how to [...]
+**Describe the problem**
+<!-- What is currently unclear to you? E.g: I can't figure out how to... -->
 
-**Which page(s) on the documentation did you refer to?**
-* https://docs.gmodnet.xyz/[...]
-* 
+**Documentation already consulted**
+<!-- A list of links to the [documentation](https://docs.gmodnet.xyz/) where you already tried, or expected, to find answers. -->
 
-**Does the documentation contain no information or is information unclear?**
-- [ ] The documentation has some information on my problem.
-- [x] The documentation describes nothing on my problem.
-- [ ] The documentation has information, but it is incorrect.
+**Current state of the documentation**
+- [ ] The documentation has some information related to my problem.
+- [x] The documentation describes nothing related to my problem.
+- [ ] The documentation has information that could help with my problem, but it is incorrect/incomplete.
 
-**Additional context**
-Add any other context or information that can help us decide if/how we need to update the documentation.
+# Additional context
+<!-- Add any other context or information that can help us decide if/how we need to update the documentation. -->

--- a/.github/ISSUE_TEMPLATE/docs_question.md
+++ b/.github/ISSUE_TEMPLATE/docs_question.md
@@ -1,0 +1,22 @@
+---
+name: Documentation question/improvement
+about: Ask a question the documentation doesn't answer
+title: "[DOC]"
+labels: documentation
+assignees: ''
+---
+
+**What is currently unclear to you? Describe the problem you are experiencing.**
+E.g: I can't figure out how to [...]
+
+**Which page(s) on the documentation did you refer to?**
+* https://docs.gmodnet.xyz/[...]
+* 
+
+**Does the documentation contain no information or is information unclear?**
+- [ ] The documentation has some information on my problem.
+- [x] The documentation describes nothing on my problem.
+- [ ] The documentation has information, but it is incorrect.
+
+**Additional context**
+Add any other context or information that can help us decide if/how we need to update the documentation.

--- a/.github/ISSUE_TEMPLATE/docs_question.md
+++ b/.github/ISSUE_TEMPLATE/docs_question.md
@@ -6,7 +6,7 @@ labels: documentation
 assignees: ''
 ---
 
-# Describe the problem
+# Problem
 <!-- What is currently unclear to you? E.g: I can't figure out how to... -->
 
 # Documentation already consulted
@@ -14,7 +14,9 @@ assignees: ''
 
 # Current state of the documentation
 - [ ] The documentation has some information related to my problem.
-- [x] The documentation describes nothing related to my problem.
+
+- [ ] The documentation describes nothing related to my problem.
+
 - [ ] The documentation has information that could help with my problem, but it is incorrect/incomplete.
 
 # Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,13 +6,13 @@ labels: enhancement
 assignees: ''
 ---
 
-# Describe the problem this feature aims to solve
-<!-- A clear and concise description of what the problem is your idea tries to solve. E.g: I'm always frustrated when... -->
+# Your suggestion
+<!-- A clear and concise description of what you want to happen. -->
 
-# Describe the solution to the above problem
-<!-- A clear and concise description of what you want to happen -->
+# The problem this suggestion solves
+<!-- A clear and concise description of what the problem is your suggestion tries to solve. E.g: I'm always frustrated when... -->
 
-# Describe alternatives you've considered
+# Alternatives
 <!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 # Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,13 +6,13 @@ labels: enhancement
 assignees: ''
 ---
 
-**Describe the problem this feature aims to solve**
+# Describe the problem this feature aims to solve
 <!-- A clear and concise description of what the problem is your idea tries to solve. E.g: I'm always frustrated when... -->
 
-**Describe the solution to the above problem**
+# Describe the solution to the above problem
 <!-- A clear and concise description of what you want to happen -->
 
-**Describe alternatives you've considered**
+# Describe alternatives you've considered
 <!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 # Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,14 +6,14 @@ labels: enhancement
 assignees: ''
 ---
 
-**Is your feature request related to a problem/struggle? Please describe.**
-A clear and concise description of what the problem is your idea tries to sovle. E.g: I'm always frustrated when [...]
+**Describe the problem this feature aims to solve**
+<!-- A clear and concise description of what the problem is your idea tries to solve. E.g: I'm always frustrated when... -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Describe the solution to the above problem**
+<!-- A clear and concise description of what you want to happen -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+# Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature/Enhancement request
+about: Suggest an idea for this project
+title: "[ENH]"
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem/struggle? Please describe.**
+A clear and concise description of what the problem is your idea tries to sovle. E.g: I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Right now there's only a BUG template which automatically assigns the bug label.

I imagine contributors might want to also add [ENH] issues or even [DOCS] issues. 

I'm thinking specifically of a [DOCS] issues that could be used for users' questions as a result of unclear documentation. If a question is repeated often or we agree that the documentation is unclear we could improve the docs.