### PR TITLE
allow dev with sdk 7.0.202 to build

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.102"
+    "version": "7.0.102",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Small change to be less strict on the required sdk version. Allows me to build (I have dotnet sdk version 7.0.202)